### PR TITLE
Add search history feature with dropdown UI

### DIFF
--- a/bluesky-term-search.html
+++ b/bluesky-term-search.html
@@ -747,7 +747,7 @@
             margin-bottom: 0;
         }
 
-        .thread-context + .post {
+        .thread-context+.post {
             border-top-left-radius: 0;
             border-top-right-radius: 0;
             margin-top: 0;
@@ -1109,7 +1109,8 @@
                 </div>
             </div>
             <div class="form-group small refresh-link">
-                <a class="thread-link" href="https://bskyfeed-watch.fly.dev/" target="_blank" rel="noopener noreferrer">Custom keyword feed</a>
+                <a class="thread-link" href="https://bskyfeed-watch.fly.dev/" target="_blank"
+                    rel="noopener noreferrer">Custom keyword feed</a>
             </div>
         </div>
     </div>
@@ -1174,7 +1175,7 @@
         let timeFilterHours = 24;
         let isLoading = false;
         let isRefreshing = false;
-        let pendingSearch = false;
+        let pendingSearch = null;  // null = no pending search, boolean = saveToHistory value for pending search
         let renderLimit = INITIAL_RENDER_LIMIT;
         let autoRefreshEnabled = false;
         let refreshIntervalMs = 5 * 60 * 1000;
@@ -1445,7 +1446,6 @@
 
                 div.addEventListener('click', () => {
                     applyHistoryEntry(entry);
-                    hideSearchHistoryDropdown();
                 });
 
                 dropdown.appendChild(div);
@@ -1508,6 +1508,12 @@
         function handleHistoryKeydown(e) {
             if (!historyDropdownVisible) return;
 
+            // Always allow Escape to close the dropdown, even when history is empty
+            if (e.key === 'Escape') {
+                hideSearchHistoryDropdown();
+                return;
+            }
+
             const history = loadSearchHistory();
             if (history.length === 0) return;
 
@@ -1528,9 +1534,6 @@
                     return;
                 }
                 applyHistoryEntry(selected);
-                hideSearchHistoryDropdown();
-            } else if (e.key === 'Escape') {
-                hideSearchHistoryDropdown();
             } else if (e.key === 'Delete' && historySelectedIndex >= 0) {
                 e.preventDefault();
                 removeFromSearchHistory(history[historySelectedIndex].id);
@@ -2939,10 +2942,10 @@
             hideSearchHistoryDropdown();
 
             if (isLoading) {
-                pendingSearch = true;
+                pendingSearch = saveToHistory;
                 return;
             }
-            pendingSearch = false;
+            pendingSearch = null;
             const termsValue = termsInput.value.trim();
             if (!termsValue) {
                 showStatus('Please enter at least one search term.', 'error');
@@ -3017,9 +3020,10 @@
                 if (autoRefreshEnabled && searchCompleted) {
                     scheduleNextRefresh();
                 }
-                if (pendingSearch) {
-                    pendingSearch = false;
-                    performSearch();
+                if (pendingSearch !== null) {
+                    const pendingSaveToHistory = pendingSearch;
+                    pendingSearch = null;
+                    performSearch(pendingSaveToHistory);
                 }
             }
         }
@@ -3157,7 +3161,7 @@
             updateExpansionSummary();
             if (!termsInput.value.trim()) {
                 cancelDebouncedSearch();
-                pendingSearch = false;
+                pendingSearch = null;
                 return;
             }
             debouncedSearch();


### PR DESCRIPTION
## Summary
Adds a persistent search history feature that stores recent searches in localStorage and displays them in a dropdown UI when the search input is focused.

## Features
- **Persistent storage**: History survives page refresh and browser restart (max 50 entries)
- **Smart deduplication**: Same search configuration updates existing entry instead of creating duplicate
- **Full parameter recall**: Clicking a history entry restores all search settings (terms, likes, time filter, sort, expand)
- **Keyboard navigation**: Arrow keys to navigate, Enter to select, Delete to remove entry, Escape to close
- **Privacy controls**: Delete individual entries with × button or clear all history

## Technical Details
- Schema-versioned localStorage with validation and sanitization on load
- Input length limits (500 chars for terms) to prevent abuse
- Only saves user-initiated searches (not auto-refresh or URL-loaded)
- Debounced searches don't save to history

## Bug Fixes (Latest Commit)
- **Escape key fix**: Fixed Escape key not working when history is empty. Previously, the early return for empty history prevented the Escape handler from executing, leaving users stuck with a visible "No recent searches" dropdown that couldn't be dismissed via keyboard.
- **Removed redundant code**: Cleaned up duplicate `hideSearchHistoryDropdown()` calls since `performSearch()` already closes the dropdown.
- **Pending search state**: Fixed `pendingSearch` to preserve the `saveToHistory` flag so queued searches correctly remember whether they should be saved to history.

## Test Plan
- [ ] Perform a search and verify it appears in history dropdown
- [ ] Click a history entry and verify all parameters are restored
- [ ] Test keyboard navigation (↑/↓/Enter/Delete/Esc)
- [ ] Delete individual entries with × button
- [ ] Clear all history and verify confirmation dialog
- [ ] Refresh page and verify history persists
- [ ] Test with 50+ searches to verify max limit
- [ ] Delete all entries via keyboard and verify Escape closes the empty dropdown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a persistent search history with a dropdown UI integrated into the search field.
> 
> - Stores recent searches in `localStorage` (max 50, versioned, validated/sanitized) with smart deduping by query parameters
> - New dropdown (`searchHistoryDropdown`) shows recent terms with metadata (likes/time/sort/expand, result count), supports per-entry delete and clear-all
> - Full keyboard support: ArrowUp/Down selection, Enter to apply, Delete to remove, Escape to close; Enter on input respects selection state
> - Clicking a history entry restores all parameters and re-runs search; debounced searches don’t save to history; `performSearch(saveToHistory)` and `pendingSearch` updated to handle concurrency
> - Adds related styles and input wrapper; minor CSS tweak for `.thread-context+.post` selector and small markup formatting changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfae44c2185f2566d0816c6f5e0c7113433f0175. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->