### PR TITLE
Harden @claude workflow and serve from dist

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,26 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,4 +63,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 node_modules/
 app.min.js
 styles.min.css
+dist/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "minify:js": "terser app.js -o app.min.js --compress --mangle",
     "minify:css": "postcss styles.css --use cssnano --no-map -o styles.min.css",
-    "build": "npm run minify:js && npm run minify:css",
+    "build": "npm run minify:js && npm run minify:css && node scripts/prepare-dist.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/scripts/prepare-dist.js
+++ b/scripts/prepare-dist.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+const distDir = path.join(__dirname, '..', 'dist');
+const files = [
+  'bluesky-term-search.html',
+  'app.min.js',
+  'styles.min.css',
+];
+
+fs.mkdirSync(distDir, { recursive: true });
+
+for (const file of files) {
+  const src = path.join(__dirname, '..', file);
+  const dest = path.join(distDir, file);
+  if (!fs.existsSync(src)) {
+    throw new Error(`Missing build artifact: ${file}`);
+  }
+  fs.copyFileSync(src, dest);
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "buildCommand": "npm run build",
-  "outputDirectory": ".",
+  "outputDirectory": "dist",
   "rewrites": [
     {
       "source": "/",


### PR DESCRIPTION
## Summary
- restrict @claude triggers to trusted author associations
- serve static output from dist via Vercel build step
- add dist to .gitignore

## Testing
- npm run build
