### PR TITLE
Hide images by default with per-post reveal button

### DIFF
--- a/app.js
+++ b/app.js
@@ -1177,24 +1177,42 @@ function createPostElement(post) {
     textDiv.appendChild(createHighlightedText(text, searchTerms));
     postDiv.appendChild(textDiv);
 
-    // Images
+    // Images (hidden by default)
     if (post.embed?.$type === 'app.bsky.embed.images#view' && post.embed.images) {
-        const imagesDiv = document.createElement('div');
-        imagesDiv.className = 'post-images ' + (post.embed.images.length === 1 ? 'single' : 'multiple');
+        const validImages = post.embed.images.filter(img => img.thumb && isValidBskyUrl(img.thumb));
 
-        post.embed.images.forEach(img => {
-            if (img.thumb && isValidBskyUrl(img.thumb)) {
-                const imgEl = document.createElement('img');
-                imgEl.className = 'post-image';
-                imgEl.src = img.thumb;
-                imgEl.alt = img.alt || '';
-                imgEl.loading = 'lazy';
-                imagesDiv.appendChild(imgEl);
-            }
-        });
+        if (validImages.length > 0) {
+            const imagesContainer = document.createElement('div');
+            imagesContainer.className = 'post-images-container';
 
-        if (imagesDiv.children.length > 0) {
-            postDiv.appendChild(imagesDiv);
+            // Create placeholder
+            const placeholder = document.createElement('div');
+            placeholder.className = 'image-placeholder';
+
+            const showBtn = document.createElement('button');
+            showBtn.type = 'button';
+            const count = validImages.length;
+            showBtn.textContent = `Show ${count} image${count !== 1 ? 's' : ''}`;
+            showBtn.addEventListener('click', () => {
+                // Replace placeholder with actual images
+                const imagesDiv = document.createElement('div');
+                imagesDiv.className = 'post-images ' + (validImages.length === 1 ? 'single' : 'multiple');
+
+                validImages.forEach(img => {
+                    const imgEl = document.createElement('img');
+                    imgEl.className = 'post-image';
+                    imgEl.src = img.thumb;
+                    imgEl.alt = img.alt || '';
+                    imgEl.loading = 'lazy';
+                    imagesDiv.appendChild(imgEl);
+                });
+
+                imagesContainer.replaceChild(imagesDiv, placeholder);
+            });
+
+            placeholder.appendChild(showBtn);
+            imagesContainer.appendChild(placeholder);
+            postDiv.appendChild(imagesContainer);
         }
     }
 

--- a/styles.css
+++ b/styles.css
@@ -485,6 +485,35 @@ button:disabled {
     object-fit: cover;
 }
 
+.post-images-container {
+    margin-bottom: 12px;
+}
+
+.image-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    background: var(--surface);
+    border: 1px dashed var(--border);
+    border-radius: 8px;
+}
+
+.image-placeholder button {
+    background: none;
+    border: none;
+    color: var(--accent);
+    cursor: pointer;
+    font-size: 14px;
+    font-family: inherit;
+    padding: 0;
+}
+
+.image-placeholder button:hover {
+    text-decoration: underline;
+    background: none;
+}
+
 .post-stats {
     display: flex;
     gap: 20px;


### PR DESCRIPTION
## Summary
- Images in search results are now hidden by default behind a placeholder
- Each post shows a "Show X image(s)" button that reveals images on click
- Improves privacy, reduces bandwidth, and gives users control over content

## Test plan
- [ ] Search for posts that contain images
- [ ] Verify placeholder appears with correct image count
- [ ] Click "Show images" button and verify images load
- [ ] Test with single image and multiple image posts
- [ ] Verify styling works in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)