### PR TITLE
Fix cache key collision vulnerability

### DIFF
--- a/api/search.js
+++ b/api/search.js
@@ -130,7 +130,7 @@ async function refreshOrCreateSession() {
 
 // Generate cache key for search results
 function getSearchCacheKey(term, cursor, sort) {
-  return `${term}|${cursor || ''}|${sort}`;
+  return JSON.stringify([term, cursor || '', sort]);
 }
 
 // Get cached search result if valid

--- a/app.js
+++ b/app.js
@@ -281,7 +281,7 @@ function updateExpansionSummary() {
 
 // Generate cache key for search requests
 function getSearchCacheKey(term, cursor, sort) {
-    return `${term}|${cursor || ''}|${sort}`;
+    return JSON.stringify([term, cursor || '', sort]);
 }
 
 // Check if cached result is still valid


### PR DESCRIPTION
## Problem

The search results cache key used a pipe-delimited string:
```js
return `${term}|${cursor || ''}|${sort}`;
```

This is vulnerable to **cache key collisions** when `term` or `cursor` contains the `|` character. For example:
- `term="a|b", cursor="c"` → `"a|b|c|top"`
- `term="a", cursor="b|c"` → `"a|b|c|top"`

This could cause one query's results to be cached and served for a different query (cache poisoning).

## Solution

Use `JSON.stringify()` to produce unique, collision-resistant keys:
```js
return JSON.stringify([term, cursor || '', sort]);
```

Found during security audit of recent commits.