### PR TITLE
[codex] Autofocus terms input

### DIFF
--- a/app.js
+++ b/app.js
@@ -154,8 +154,12 @@ function updateQuoteTabs() {
 
 function focusSearchInput() {
     if (!termsInput) return;
-    termsInput.focus();
-    termsInput.select();
+    if (typeof termsInput.focus === 'function') {
+        termsInput.focus();
+    }
+    if (typeof termsInput.select === 'function') {
+        termsInput.select();
+    }
 }
 
 // Initialize from URL params


### PR DESCRIPTION
## Summary
This change makes the main search input auto-focused and selected on page load, so users can start typing immediately when the app opens on Vercel.

## Problem
The landing page loads without focus on the search box, forcing users to click before typing. That adds friction for the primary action.

## Root Cause
There was no initialization step that focuses the `#terms` input after the DOM is ready.

## Fix
Add a small helper that calls `focus()` and `select()` on the terms input during initialization. Guard these calls so tests (which use a minimal DOM mock) continue to run without errors.

## Tests
- `npm test`
