### PR TITLE
[codex] separate search and quote sort URL params

### DIFF
--- a/src/app.mjs
+++ b/src/app.mjs
@@ -39,6 +39,10 @@ import {
   initTheme,
   prefersDarkScheme,
 } from './theme.mjs';
+import { updateURLWithParams } from './url.mjs';
+
+const SEARCH_SORT_VALUES = ['top', 'latest'];
+const QUOTE_SORT_VALUES = ['likes', 'recent', 'oldest'];
 
 function initFromURL() {
   const params = new URLSearchParams(window.location.search);
@@ -54,11 +58,17 @@ function initFromURL() {
       timeFilterSelect.value = timeValue;
     }
   }
-  if (params.get('sort')) {
-    const sortValue = params.get('sort');
-    if (['top', 'latest'].includes(sortValue)) {
-      sortSelect.value = sortValue;
-    }
+  const searchSortParam = params.get('searchSort');
+  const legacySortParam = params.get('sort');
+  const hasValidSearchSort = SEARCH_SORT_VALUES.includes(searchSortParam);
+  const hasValidLegacySearchSort = SEARCH_SORT_VALUES.includes(legacySortParam);
+  const resolvedSearchSort = hasValidSearchSort
+    ? searchSortParam
+    : hasValidLegacySearchSort
+      ? legacySortParam
+      : null;
+  if (resolvedSearchSort) {
+    sortSelect.value = resolvedSearchSort;
   }
   state.searchSort = normalizeSortValue(sortSelect.value);
   if (params.get('expand') === '1') {
@@ -66,14 +76,32 @@ function initFromURL() {
   }
 
   const postParam = params.get('post');
-  const sortParam = params.get('sort');
-  if (sortParam && ['likes', 'recent', 'oldest'].includes(sortParam)) {
-    state.quoteSort = sortParam;
+  const quoteSortParam = params.get('quoteSort');
+  const hasValidQuoteSort = QUOTE_SORT_VALUES.includes(quoteSortParam);
+  const hasValidLegacyQuoteSort = QUOTE_SORT_VALUES.includes(legacySortParam);
+  const resolvedQuoteSort = hasValidQuoteSort
+    ? quoteSortParam
+    : hasValidLegacyQuoteSort
+      ? legacySortParam
+      : null;
+  if (resolvedQuoteSort) {
+    state.quoteSort = resolvedQuoteSort;
     updateQuoteTabs();
   }
   if (postParam) {
     postUrlInput.value = postParam;
     performQuoteSearch();
+  }
+
+  if (!hasValidSearchSort && hasValidLegacySearchSort) {
+    params.set('searchSort', legacySortParam);
+  }
+  if (!hasValidQuoteSort && hasValidLegacyQuoteSort) {
+    params.set('quoteSort', legacySortParam);
+  }
+  if ((!hasValidSearchSort && hasValidLegacySearchSort) || (!hasValidQuoteSort && hasValidLegacyQuoteSort)) {
+    params.delete('sort');
+    updateURLWithParams(params);
   }
 
   updateExpansionSummary();

--- a/src/quotes.mjs
+++ b/src/quotes.mjs
@@ -36,10 +36,11 @@ export function updateQuoteURL() {
   const postValue = postUrlInput.value.trim();
   setQueryParam(params, 'post', postValue);
   if (postValue && state.quoteSort !== 'likes') {
-    params.set('sort', state.quoteSort);
+    params.set('quoteSort', state.quoteSort);
   } else {
-    params.delete('sort');
+    params.delete('quoteSort');
   }
+  params.delete('sort');
   updateURLWithParams(params);
 }
 

--- a/src/search.mjs
+++ b/src/search.mjs
@@ -84,8 +84,9 @@ export function updateSearchURL() {
   setQueryParam(params, 'terms', termsInput.value.trim());
   setQueryParam(params, 'minLikes', minLikesInput.value);
   setQueryParam(params, 'time', timeFilterSelect.value !== '24' ? timeFilterSelect.value : '');
-  setQueryParam(params, 'sort', state.searchSort !== 'top' ? state.searchSort : '');
+  setQueryParam(params, 'searchSort', state.searchSort !== 'top' ? state.searchSort : '');
   setQueryParam(params, 'expand', expandTermsToggle.checked ? '1' : '');
+  params.delete('sort');
   updateURLWithParams(params);
 }
 

--- a/tests/app-events.test.js
+++ b/tests/app-events.test.js
@@ -74,6 +74,10 @@ const mocks = vi.hoisted(() => {
     prefersDarkScheme: { addEventListener: vi.fn() },
   };
 
+  const url = {
+    updateURLWithParams: vi.fn(),
+  };
+
   const reset = () => {
     dom.autoRefreshToggle.reset({ checked: false });
     dom.expandTermsToggle.reset({ checked: false });
@@ -93,7 +97,7 @@ const mocks = vi.hoisted(() => {
     state.quoteSort = 'likes';
     state.searchSort = 'top';
 
-    for (const mod of [search, quotes, theme]) {
+    for (const mod of [search, quotes, theme, url]) {
       for (const val of Object.values(mod)) {
         if (typeof val?.mockClear === 'function') val.mockClear();
         if (typeof val?.addEventListener?.mockClear === 'function') val.addEventListener.mockClear();
@@ -108,6 +112,7 @@ const mocks = vi.hoisted(() => {
     search,
     state,
     theme,
+    url,
   };
 });
 
@@ -119,6 +124,7 @@ vi.mock('../src/utils.mjs', () => ({
 vi.mock('../src/search.mjs', () => mocks.search);
 vi.mock('../src/quotes.mjs', () => mocks.quotes);
 vi.mock('../src/theme.mjs', () => mocks.theme);
+vi.mock('../src/url.mjs', () => mocks.url);
 
 async function bootApp() {
   await import('../src/app.mjs');
@@ -175,5 +181,79 @@ describe('app sort change handler', () => {
     mocks.dom.sortSelect.dispatch('change');
 
     expect(mocks.search.scheduleNextRefresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('app URL initialization', () => {
+  let originalWindow;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.reset();
+    originalWindow = globalThis.window;
+  });
+
+  afterEach(() => {
+    if (originalWindow === undefined) {
+      delete globalThis.window;
+      return;
+    }
+    globalThis.window = originalWindow;
+  });
+
+  it('reads distinct searchSort and quoteSort params without collisions', async () => {
+    globalThis.window = {
+      location: {
+        search:
+          '?searchSort=latest&post=https%3A%2F%2Fbsky.app%2Fprofile%2Falice%2Fpost%2F123&quoteSort=recent',
+      },
+    };
+
+    await bootApp();
+
+    expect(mocks.dom.sortSelect.value).toBe('latest');
+    expect(mocks.state.searchSort).toBe('latest');
+    expect(mocks.state.quoteSort).toBe('recent');
+    expect(mocks.quotes.updateQuoteTabs).toHaveBeenCalledTimes(1);
+    expect(mocks.quotes.performQuoteSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.url.updateURLWithParams).not.toHaveBeenCalled();
+  });
+
+  it('migrates legacy search sort links to searchSort', async () => {
+    globalThis.window = {
+      location: {
+        search: '?sort=latest',
+      },
+    };
+
+    await bootApp();
+
+    expect(mocks.dom.sortSelect.value).toBe('latest');
+    expect(mocks.state.searchSort).toBe('latest');
+    expect(mocks.state.quoteSort).toBe('likes');
+    expect(mocks.url.updateURLWithParams).toHaveBeenCalledTimes(1);
+    const params = mocks.url.updateURLWithParams.mock.calls[0][0];
+    expect(params.get('searchSort')).toBe('latest');
+    expect(params.get('sort')).toBe(null);
+  });
+
+  it('migrates legacy quote sort links to quoteSort', async () => {
+    globalThis.window = {
+      location: {
+        search:
+          '?post=https%3A%2F%2Fbsky.app%2Fprofile%2Falice%2Fpost%2F123&sort=recent',
+      },
+    };
+
+    await bootApp();
+
+    expect(mocks.state.quoteSort).toBe('recent');
+    expect(mocks.quotes.updateQuoteTabs).toHaveBeenCalledTimes(1);
+    expect(mocks.quotes.performQuoteSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.url.updateURLWithParams).toHaveBeenCalledTimes(1);
+    const params = mocks.url.updateURLWithParams.mock.calls[0][0];
+    expect(params.get('post')).toBe('https://bsky.app/profile/alice/post/123');
+    expect(params.get('quoteSort')).toBe('recent');
+    expect(params.get('sort')).toBe(null);
   });
 });


### PR DESCRIPTION
## Summary

This fixes a URL-state collision between the search results view and the quote finder.

Before this change, both features stored their sort preference in the same `sort` query parameter. Changing the search sort could overwrite the quote sort in the address bar, and changing the quote sort could do the reverse. Shared links could then restore the wrong UI state on reload.

## Root Cause

The search flow in `src/search.mjs` and the quote flow in `src/quotes.mjs` were both writing to `sort`, while `src/app.mjs` tried to interpret that same key for two different sort enums during bootstrap.

## Fix

- Search URLs now use `searchSort`.
- Quote URLs now use `quoteSort`.
- App bootstrap reads the two params independently.
- Legacy `sort=` links are migrated on load so older shared URLs still keep working.
- Added bootstrap tests covering the split-param behavior and the legacy-link migration.

## Validation

- `npm test`
