### PR TITLE
[codex] Fix queued search after loading more

### DIFF
--- a/src/search-state.mjs
+++ b/src/search-state.mjs
@@ -1,0 +1,8 @@
+export function consumePendingSearch(state) {
+  if (!state.pendingSearch) {
+    return false;
+  }
+
+  state.pendingSearch = false;
+  return true;
+}

--- a/src/search.mjs
+++ b/src/search.mjs
@@ -41,6 +41,7 @@ import {
   sortPosts,
 } from './utils.mjs';
 import { enforceSearchCacheLimit, getCachedSearch } from './cache.mjs';
+import { consumePendingSearch } from './search-state.mjs';
 import { setQueryParam, updateURLWithParams } from './url.mjs';
 import { isReplyPost, toggleThread } from './thread.mjs';
 
@@ -1120,8 +1121,7 @@ export async function performSearch() {
     if (state.autoRefreshEnabled && searchCompleted) {
       scheduleNextRefresh();
     }
-    if (state.pendingSearch) {
-      state.pendingSearch = false;
+    if (consumePendingSearch(state)) {
       performSearch();
     }
   }
@@ -1174,6 +1174,9 @@ export async function loadMore() {
     if (loadMoreBtn) {
       loadMoreBtn.disabled = false;
       loadMoreBtn.textContent = 'Load More Results';
+    }
+    if (consumePendingSearch(state)) {
+      performSearch();
     }
   }
 }

--- a/src/testing.mjs
+++ b/src/testing.mjs
@@ -12,6 +12,7 @@ export {
   sortPosts,
 } from './utils.mjs';
 export { trackQuoteCursor } from './quotes-state.mjs';
+export { consumePendingSearch } from './search-state.mjs';
 export { enforceSearchCacheLimit, enforceDidCacheLimit, getCachedDid } from './cache.mjs';
 export { didCache, isCurrentSearchGeneration, searchCache, state } from './state.mjs';
 export { DID_CACHE_TTL_MS, MAX_SEARCH_CACHE_SIZE, MAX_DID_CACHE_SIZE } from './constants.mjs';

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -27,12 +27,30 @@ const {
   state,
   isCurrentSearchGeneration,
   searchCache,
+  consumePendingSearch,
   DID_CACHE_TTL_MS,
   MAX_SEARCH_CACHE_SIZE,
   MAX_DID_CACHE_SIZE,
   enforceSearchCacheLimit,
   enforceDidCacheLimit,
 } = app;
+
+describe('consumePendingSearch', () => {
+  it('clears and reports a queued search exactly once', () => {
+    const pendingState = { pendingSearch: true };
+
+    expect(consumePendingSearch(pendingState)).toBe(true);
+    expect(pendingState.pendingSearch).toBe(false);
+    expect(consumePendingSearch(pendingState)).toBe(false);
+  });
+
+  it('leaves state unchanged when no search is queued', () => {
+    const pendingState = { pendingSearch: false };
+
+    expect(consumePendingSearch(pendingState)).toBe(false);
+    expect(pendingState.pendingSearch).toBe(false);
+  });
+});
 
 // ============================================================================
 // isValidBskyUrl


### PR DESCRIPTION
## Summary
- Replay queued searches after a Load More request finishes
- Share pending-search consumption between full search and pagination paths
- Add regression coverage for one-shot pending-search consumption

## Root Cause
Both full search and pagination used the same `state.isLoading` flag. If a user started a new search while Load More was running, `performSearch()` marked `state.pendingSearch` and returned, but only the full search path drained that pending flag. The pagination path cleared loading without replaying the queued search.

## Validation
- `npm test`
- `npm run build`
- `npm run perf:smoke`