### PR TITLE
Fix stale search results when the search field is cleared

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1963,9 +1963,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1986,9 +1986,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -2899,9 +2899,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3119,9 +3119,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3205,9 +3205,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3263,9 +3263,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/src/app.mjs
+++ b/src/app.mjs
@@ -17,6 +17,7 @@ import {
 import {
   applySearchSortChange,
   cancelDebouncedSearch,
+  clearSearchResults,
   debouncedSearch,
   disableAutoRefresh,
   enableAutoRefresh,
@@ -167,7 +168,7 @@ termsInput.addEventListener('input', () => {
   updateExpansionSummary();
   if (!termsInput.value.trim()) {
     cancelDebouncedSearch();
-    state.pendingSearch = false;
+    clearSearchResults();
     return;
   }
   debouncedSearch();

--- a/src/search.mjs
+++ b/src/search.mjs
@@ -1238,7 +1238,7 @@ export function clearSearchResults() {
   state.rawSearchTerms = [];
   state.searchTerms = [];
   state.pendingPosts = [];
-  state.newPostUris.clear();
+  clearNewPostHighlights();
   clearDerivedPostsTimer();
   clearIngestedPosts();
   resetRenderLimit();

--- a/src/search.mjs
+++ b/src/search.mjs
@@ -926,22 +926,31 @@ async function refreshSearch() {
     return 0;
   }
 
+  const currentGeneration = state.searchGeneration;
+  const searchTerms = [...state.searchTerms];
+  const searchSort = state.searchSort;
+  const minLikes = state.minLikes;
+  const timeFilterHours = state.timeFilterHours;
   const retainedPosts = pruneIngestedPostsByCurrentFilters();
-  state.allPosts = sortPosts(retainedPosts, state.searchSort);
+  state.allPosts = sortPosts(retainedPosts, searchSort);
 
-  state.pendingPosts = filterByDate(state.pendingPosts, state.timeFilterHours);
-  state.pendingPosts = filterByLikes(state.pendingPosts, state.minLikes);
+  state.pendingPosts = filterByDate(state.pendingPosts, timeFilterHours);
+  state.pendingPosts = filterByLikes(state.pendingPosts, minLikes);
 
   const existingUris = new Set([
     ...Array.from(ingestedPostsByUri.keys()),
     ...state.pendingPosts.map((post) => post.uri),
   ]);
   const results = await Promise.all(
-    state.searchTerms.map((term) => fetchLatestPostsForTerm(term, state.searchSort))
+    searchTerms.map((term) => fetchLatestPostsForTerm(term, searchSort))
   );
+  if (!isCurrentSearchGeneration(currentGeneration)) {
+    return null;
+  }
+
   let latestPosts = deduplicatePosts(results.flat());
-  latestPosts = filterByDate(latestPosts, state.timeFilterHours);
-  latestPosts = filterByLikes(latestPosts, state.minLikes);
+  latestPosts = filterByDate(latestPosts, timeFilterHours);
+  latestPosts = filterByLikes(latestPosts, minLikes);
 
   const newPosts = latestPosts.filter((post) => !existingUris.has(post.uri));
 
@@ -984,7 +993,11 @@ async function runAutoRefresh() {
   updateRefreshMeta();
 
   try {
+    const currentGeneration = state.searchGeneration;
     const newCount = await refreshSearch();
+    if (newCount === null || !isCurrentSearchGeneration(currentGeneration)) {
+      return;
+    }
     state.lastRefreshAt = new Date();
     state.lastRefreshNewCount = newCount;
   } catch (error) {
@@ -1131,6 +1144,7 @@ export async function performSearch() {
 export async function loadMore() {
   if (state.isLoading) return;
 
+  const currentGeneration = state.searchGeneration;
   const prevCount = state.allPosts.length;
   state.isLoading = true;
   const loadMoreBtn = loadMoreBtnEl || document.getElementById('loadMoreBtn');
@@ -1140,23 +1154,37 @@ export async function loadMore() {
   }
 
   try {
-    const promises = state.searchTerms
-      .filter((term) => state.currentCursors[term])
-      .map(async (term) => {
-        const data = await searchTerm(term, state.currentCursors[term], state.searchSort);
-        state.currentCursors[term] = data.cursor || null;
+    const searchSort = state.searchSort;
+    const requests = state.searchTerms
+      .map((term) => ({ term, cursor: state.currentCursors[term] }))
+      .filter((request) => request.cursor);
+    const promises = requests
+      .map(async ({ term, cursor }) => {
+        const data = await searchTerm(term, cursor, searchSort);
 
         if (data.posts && data.posts.length > 0) {
-          return data.posts.map((post) => ({
-            ...post,
-            matchedTerm: term,
-          }));
+          return {
+            cursor: data.cursor || null,
+            posts: data.posts.map((post) => ({
+              ...post,
+              matchedTerm: term,
+            })),
+            term,
+          };
         }
-        return [];
+        return { cursor: data.cursor || null, posts: [], term };
       });
 
     const results = await Promise.all(promises);
-    const newPosts = results.flat();
+    if (!isCurrentSearchGeneration(currentGeneration)) {
+      return;
+    }
+
+    results.forEach((result) => {
+      state.currentCursors[result.term] = result.cursor;
+    });
+
+    const newPosts = results.flatMap((result) => result.posts);
 
     if (newPosts.length > 0) {
       ingestPosts(newPosts);

--- a/src/search.mjs
+++ b/src/search.mjs
@@ -1198,6 +1198,25 @@ export function cancelDebouncedSearch() {
   }
 }
 
+export function clearSearchResults() {
+  state.pendingSearch = false;
+  state.searchGeneration++;
+  state.allPosts = [];
+  state.currentCursors = {};
+  state.rawSearchTerms = [];
+  state.searchTerms = [];
+  state.pendingPosts = [];
+  state.newPostUris.clear();
+  clearDerivedPostsTimer();
+  clearIngestedPosts();
+  resetRenderLimit();
+  resetResultsRenderCache();
+  renderNewPosts();
+  hideStatus();
+  updateSearchURL();
+  updateRefreshMeta();
+}
+
 export function focusSearchInput() {
   if (!termsInput) return;
   if (typeof termsInput.focus === 'function') {

--- a/src/search.mjs
+++ b/src/search.mjs
@@ -1229,6 +1229,10 @@ export function cancelDebouncedSearch() {
 export function clearSearchResults() {
   state.pendingSearch = false;
   state.searchGeneration++;
+  state.autoRefreshEnabled = false;
+  autoRefreshToggle.checked = false;
+  clearRefreshTimers();
+  state.nextRefreshAt = null;
   state.allPosts = [];
   state.currentCursors = {};
   state.rawSearchTerms = [];

--- a/tests/app-events.test.js
+++ b/tests/app-events.test.js
@@ -49,6 +49,7 @@ const mocks = vi.hoisted(() => {
   const search = {
     applySearchSortChange: vi.fn(),
     cancelDebouncedSearch: vi.fn(),
+    clearSearchResults: vi.fn(),
     debouncedSearch: vi.fn(),
     disableAutoRefresh: vi.fn(),
     enableAutoRefresh: vi.fn(),
@@ -181,6 +182,51 @@ describe('app sort change handler', () => {
     mocks.dom.sortSelect.dispatch('change');
 
     expect(mocks.search.scheduleNextRefresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('app search input handler', () => {
+  let originalWindow;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.reset();
+    originalWindow = globalThis.window;
+    globalThis.window = { location: { search: '' } };
+  });
+
+  afterEach(() => {
+    if (originalWindow === undefined) {
+      delete globalThis.window;
+      return;
+    }
+    globalThis.window = originalWindow;
+  });
+
+  it('clears stale results when the terms field is emptied', async () => {
+    await bootApp();
+
+    const expansionCallsBeforeInput = mocks.search.updateExpansionSummary.mock.calls.length;
+    mocks.dom.termsInput.value = '';
+    mocks.state.pendingSearch = true;
+    mocks.dom.termsInput.dispatch('input');
+
+    expect(mocks.search.updateExpansionSummary).toHaveBeenCalledTimes(expansionCallsBeforeInput + 1);
+    expect(mocks.search.cancelDebouncedSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.search.clearSearchResults).toHaveBeenCalledTimes(1);
+    expect(mocks.search.debouncedSearch).not.toHaveBeenCalled();
+  });
+
+  it('debounces search when the terms field has content', async () => {
+    await bootApp();
+
+    const expansionCallsBeforeInput = mocks.search.updateExpansionSummary.mock.calls.length;
+    mocks.dom.termsInput.value = 'apple';
+    mocks.dom.termsInput.dispatch('input');
+
+    expect(mocks.search.updateExpansionSummary).toHaveBeenCalledTimes(expansionCallsBeforeInput + 1);
+    expect(mocks.search.clearSearchResults).not.toHaveBeenCalled();
+    expect(mocks.search.debouncedSearch).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/search-race.test.js
+++ b/tests/search-race.test.js
@@ -80,12 +80,14 @@ describe('search result race guards', () => {
     state.nextRefreshAt = null;
     state.pendingPosts = [];
     state.newPostUris = new Set();
+    state.clearHighlightsTimeout = null;
     mocks.dom.autoRefreshToggle.checked = false;
   });
 
   afterEach(() => {
     if (state?.refreshTimerId) clearTimeout(state.refreshTimerId);
     if (state?.refreshCountdownId) clearInterval(state.refreshCountdownId);
+    if (state?.clearHighlightsTimeout) clearTimeout(state.clearHighlightsTimeout);
     globalThis.document = originalDocument;
     globalThis.fetch = originalFetch;
     delete globalThis.window;
@@ -136,5 +138,15 @@ describe('search result race guards', () => {
     expect(state.refreshCountdownId).toBe(null);
     expect(mocks.dom.refreshStateDiv.textContent).toBe('Auto-refresh off');
     expect(mocks.dom.refreshNextDiv.textContent).toBe('');
+  });
+
+  it('cancels pending highlight clear timers when clearing search results', () => {
+    state.newPostUris = new Set(['at://highlighted']);
+    state.clearHighlightsTimeout = setTimeout(() => {}, 8000);
+
+    search.clearSearchResults();
+
+    expect(state.newPostUris.size).toBe(0);
+    expect(state.clearHighlightsTimeout).toBe(null);
   });
 });

--- a/tests/search-race.test.js
+++ b/tests/search-race.test.js
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const classList = {
+    add: vi.fn(),
+    remove: vi.fn(),
+  };
+  const createElement = () => ({
+    addEventListener: vi.fn(),
+    appendChild: vi.fn(),
+    classList,
+    remove: vi.fn(),
+    setAttribute: vi.fn(),
+    style: {},
+    textContent: '',
+  });
+
+  const dom = {
+    autoRefreshToggle: { checked: false },
+    expandSummary: createElement(),
+    expandTermsToggle: { checked: false },
+    minLikesInput: { value: '0' },
+    newPostsDiv: createElement(),
+    refreshIntervalSelect: { value: '5' },
+    refreshLastDiv: createElement(),
+    refreshNextDiv: createElement(),
+    refreshStateDiv: createElement(),
+    resultsDiv: createElement(),
+    searchBtn: { disabled: false },
+    sortSelect: { value: 'top' },
+    statusDiv: createElement(),
+    termsInput: { value: '' },
+    timeFilterSelect: { value: '24' },
+  };
+
+  return { createElement, dom };
+});
+
+vi.mock('../src/dom.mjs', () => mocks.dom);
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, reject, resolve };
+}
+
+describe('search result race guards', () => {
+  let originalDocument;
+  let originalFetch;
+  let search;
+  let state;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    originalDocument = globalThis.document;
+    originalFetch = globalThis.fetch;
+    globalThis.document = {
+      createElement: vi.fn(mocks.createElement),
+      getElementById: vi.fn(() => null),
+    };
+    globalThis.window = {
+      history: { replaceState: vi.fn() },
+      location: { pathname: '/', search: '' },
+    };
+    search = await import('../src/search.mjs');
+    ({ state } = await import('../src/state.mjs'));
+    state.allPosts = [];
+    state.currentCursors = {};
+    state.rawSearchTerms = [];
+    state.searchTerms = [];
+    state.searchGeneration = 0;
+    state.isLoading = false;
+    state.pendingPosts = [];
+    state.newPostUris = new Set();
+  });
+
+  afterEach(() => {
+    globalThis.document = originalDocument;
+    globalThis.fetch = originalFetch;
+    delete globalThis.window;
+    vi.restoreAllMocks();
+  });
+
+  it('does not restore stale posts when input is cleared during pagination', async () => {
+    const response = deferred();
+    globalThis.fetch = vi.fn(() => response.promise);
+    state.allPosts = [{ uri: 'at://old', likeCount: 1, indexedAt: '2026-04-25T00:00:00.000Z' }];
+    state.currentCursors = { apple: 'cursor-1' };
+    state.rawSearchTerms = ['apple'];
+    state.searchTerms = ['apple'];
+    state.searchGeneration = 7;
+    mocks.dom.termsInput.value = '';
+
+    const loadMorePromise = search.loadMore();
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+
+    search.clearSearchResults();
+    response.resolve({
+      ok: true,
+      json: async () => ({
+        cursor: 'cursor-2',
+        posts: [{ uri: 'at://stale', likeCount: 100, indexedAt: '2026-04-25T01:00:00.000Z' }],
+      }),
+    });
+    await loadMorePromise;
+
+    expect(state.allPosts).toEqual([]);
+    expect(state.currentCursors).toEqual({});
+    expect(state.searchTerms).toEqual([]);
+  });
+});

--- a/tests/search-race.test.js
+++ b/tests/search-race.test.js
@@ -74,11 +74,18 @@ describe('search result race guards', () => {
     state.searchTerms = [];
     state.searchGeneration = 0;
     state.isLoading = false;
+    state.autoRefreshEnabled = false;
+    state.refreshTimerId = null;
+    state.refreshCountdownId = null;
+    state.nextRefreshAt = null;
     state.pendingPosts = [];
     state.newPostUris = new Set();
+    mocks.dom.autoRefreshToggle.checked = false;
   });
 
   afterEach(() => {
+    if (state?.refreshTimerId) clearTimeout(state.refreshTimerId);
+    if (state?.refreshCountdownId) clearInterval(state.refreshCountdownId);
     globalThis.document = originalDocument;
     globalThis.fetch = originalFetch;
     delete globalThis.window;
@@ -111,5 +118,23 @@ describe('search result race guards', () => {
     expect(state.allPosts).toEqual([]);
     expect(state.currentCursors).toEqual({});
     expect(state.searchTerms).toEqual([]);
+  });
+
+  it('turns off auto-refresh immediately when clearing search results', () => {
+    state.autoRefreshEnabled = true;
+    state.nextRefreshAt = Date.now() + 300000;
+    state.refreshTimerId = setTimeout(() => {}, 300000);
+    state.refreshCountdownId = setInterval(() => {}, 1000);
+    mocks.dom.autoRefreshToggle.checked = true;
+
+    search.clearSearchResults();
+
+    expect(state.autoRefreshEnabled).toBe(false);
+    expect(mocks.dom.autoRefreshToggle.checked).toBe(false);
+    expect(state.nextRefreshAt).toBe(null);
+    expect(state.refreshTimerId).toBe(null);
+    expect(state.refreshCountdownId).toBe(null);
+    expect(mocks.dom.refreshStateDiv.textContent).toBe('Auto-refresh off');
+    expect(mocks.dom.refreshNextDiv.textContent).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
- clear the current search state when the terms field is emptied so old results do not remain visible
- centralize the reset logic in `clearSearchResults()` to clear posts, cursors, pending state, and rendered output
- add event-level regression coverage for empty-input clearing and non-empty debounced search

## Testing
- `npm test`
- `npm run build`