### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: Tests
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/vumehta/bskySearch/security/code-scanning/1](https://github.com/vumehta/bskySearch/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged by default.  
For this specific file (`.github/workflows/test.yml`), the best non-breaking fix is to add a root-level permissions block with:

- `contents: read`

This is sufficient for `actions/checkout` and running tests/build commands, and it preserves existing behavior while removing reliance on repository/org defaults. No imports, methods, or additional definitions are needed; this is a YAML configuration-only change near the top of the file, directly after `on` (or after `name`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
